### PR TITLE
added in agency option to allow for override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Here is an example `config.txt`. Uncomment the `cloudwatch.*` values to send met
     
 The following parameters are defaults, but can be overridden by adding to `config.txt`:
 
+    NYCT.gtfsAgency=MTASBWY # if running with buses, override the agency/feed ids by modifying the input gtfs agency_id and adding this option.  Default MTA NYCT
     NYCT.feedIds=["1", "2", "11", "16", "21"]
     NYCT.routeBlacklistByFeed={"1": ["D", "N", "Q"]}
     NYCT.realtimeToStaticRouteMapByFeed={"1": {"S": "GS"}}

--- a/src/main/java/com/kurtraschke/nyctrtproxy/services/LazyTripMatcher.java
+++ b/src/main/java/com/kurtraschke/nyctrtproxy/services/LazyTripMatcher.java
@@ -49,6 +49,7 @@ import java.util.Set;
 public class LazyTripMatcher implements TripMatcher {
 
   private int _lateTripLimitSec = 3600; // 1 hour
+  private String _agencyId = "MTA NYCT";
   private GtfsRelationalDao _dao;
   private CalendarServiceData _csd;
   private boolean _looseMatchDisabled = false;
@@ -63,6 +64,12 @@ public class LazyTripMatcher implements TripMatcher {
   @Inject
   public void setCalendarServiceData(CalendarServiceData csd) {
     _csd = csd;
+  }
+  
+  @Inject(optional = true)
+  public void setAgencyMatchId(@Named("NYCT.gtfsAgency") String agencyid) {
+	  _agencyId = agencyid;
+	  _log.info("Using AgencyId "+_agencyId);
   }
 
   @Inject(optional = true)
@@ -104,7 +111,7 @@ public class LazyTripMatcher implements TripMatcher {
   private boolean addCandidates(GtfsRealtime.TripUpdateOrBuilder tu, NyctTripId id, ServiceDate sd, Set<TripMatchResult> candidates) {
 
     boolean found = false;
-    Route r = _dao.getRouteForId(new AgencyAndId("MTA NYCT", tu.getTrip().getRouteId()));
+    Route r = _dao.getRouteForId(new AgencyAndId(_agencyId, tu.getTrip().getRouteId()));
     Set<AgencyAndId> serviceIds = _csd.getServiceIdsForDate(sd);
 
     // We check through all trips. This could be easily restricted, but performance has not been a problem.


### PR DESCRIPTION
Due to NYCT buses having MTA NYCT, the GTFS ids collide.  Open Trip Planner does not like multiple feeds from the same agency and swaps back and forth between them only updating partial sets of data, even when the full GTFS is combined.  

This was the easiest app to modify, simply run sed -i -e 's/MTA\ NYCT/MTASBWY/g' *.txt, add a feed_info.txt file to the gtfs, and open trip planner will work with a little effort.