### PR TITLE
Flushing trip ID fix

### DIFF
--- a/src/main/java/com/kurtraschke/nyctrtproxy/model/NyctTrainId.java
+++ b/src/main/java/com/kurtraschke/nyctrtproxy/model/NyctTrainId.java
@@ -1,0 +1,62 @@
+package com.kurtraschke.nyctrtproxy.model;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NyctTrainId {
+    private static final Pattern _trainIdPattern = Pattern.compile(
+            "^(?<trainType>.)(?<trainRoute>[A-Z0-9]{1,2}) (?<originDepartureHours>\\d{2})(?<originDepartureMinutes>\\d{2})(?<originDeparturePlus>\\+?) ?(?<originTerminal>[A-Z0-9-]{3})/(?<destinationTerminal>[A-Z0-9-]{3})$"
+    );
+
+    private final String trainType;
+    private final String trainRoute;
+    private final int originDepartureTime;
+    private final String origin;
+    private final String destination;
+
+    public static NyctTrainId buildFromString(String trainId) {
+        Matcher m = _trainIdPattern.matcher(trainId);
+
+        if (m.matches()) {
+            String trainType = m.group("trainType");
+            String trainLine = m.group("trainRoute");
+
+            int originDepartureTime = ((Integer.parseInt(m.group("originDepartureHours")) * 60) + Integer.parseInt(m.group("originDepartureMinutes"))) * 60 + (m.group("originDeparturePlus").equals("+") ? 30 : 0);
+
+            String origin = m.group("originTerminal");
+            String destination = m.group("destinationTerminal");
+
+            return new NyctTrainId(trainType, trainLine, originDepartureTime, origin, destination);
+        } else {
+            return null;
+        }
+    }
+
+    private NyctTrainId(String trainType, String trainRoute, int originDepartureTime, String origin, String destination) {
+        this.trainType = trainType;
+        this.trainRoute = trainRoute;
+        this.originDepartureTime = originDepartureTime;
+        this.origin = origin;
+        this.destination = destination;
+    }
+
+    public String getTrainType() {
+        return trainType;
+    }
+
+    public String getTrainRoute() {
+        return trainRoute;
+    }
+
+    public int getOriginDepartureTime() {
+        return originDepartureTime;
+    }
+
+    public String getOrigin() {
+        return origin;
+    }
+
+    public String getDestination() {
+        return destination;
+    }
+}

--- a/src/main/java/com/kurtraschke/nyctrtproxy/services/TripUpdateProcessor.java
+++ b/src/main/java/com/kurtraschke/nyctrtproxy/services/TripUpdateProcessor.java
@@ -483,9 +483,12 @@ public class TripUpdateProcessor {
 
   private static String getReliefPoint(GtfsRealtime.TripUpdateOrBuilder update, int pt) {
     String trainId = update.getTrip().getExtension(GtfsRealtimeNYCT.nyctTripDescriptor).getTrainId();
-    String[] tokens = trainId.split(" ");
-    String relief = tokens[tokens.length - 1];
-    String[] points = relief.split("/");
+    NyctTrainId parsedTrainId = NyctTrainId.buildFromString(trainId);
+
+    if (parsedTrainId == null)
+      return null;
+
+    String[] points = new String[]{parsedTrainId.getOrigin(), parsedTrainId.getDestination()};
     if (pt >= points.length)
       return null;
     return points[pt];

--- a/src/test/java/com/kurtraschke/nyctrtproxy/model/NyctTrainIdTest.java
+++ b/src/test/java/com/kurtraschke/nyctrtproxy/model/NyctTrainIdTest.java
@@ -1,0 +1,58 @@
+package com.kurtraschke.nyctrtproxy.model;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NyctTrainIdTest {
+
+    @Test
+    public void buildFromStringADivision() {
+        NyctTrainId trainId = NyctTrainId.buildFromString("/6 2259+ BBR/PEL");
+
+        assertNotNull(trainId);
+        assertEquals("/", trainId.getTrainType());
+        assertEquals("6", trainId.getTrainRoute());
+        assertEquals(82770, trainId.getOriginDepartureTime());
+        assertEquals("BBR", trainId.getOrigin());
+        assertEquals("PEL", trainId.getDestination());
+    }
+
+    @Test
+    public void buildFromStringBDivision() {
+        NyctTrainId trainId = NyctTrainId.buildFromString("1FS 2309 PPK/P-A");
+
+        assertNotNull(trainId);
+        assertEquals("1", trainId.getTrainType());
+        assertEquals("FS", trainId.getTrainRoute());
+        assertEquals(83340, trainId.getOriginDepartureTime());
+        assertEquals("PPK", trainId.getOrigin());
+        assertEquals("P-A", trainId.getDestination());
+    }
+
+
+    //Note no space between the plus and the origin stop; this is (so far) the only exception to the standard format.
+    @Test
+    public void buildFromStringCanarsie() {
+        NyctTrainId trainId = NyctTrainId.buildFromString("0L 2300+8AV/MYR");
+
+        assertNotNull(trainId);
+        assertEquals("0", trainId.getTrainType());
+        assertEquals("L", trainId.getTrainRoute());
+        assertEquals(82830, trainId.getOriginDepartureTime());
+        assertEquals("8AV", trainId.getOrigin());
+        assertEquals("MYR", trainId.getDestination());
+    }
+
+    @Test
+    public void buildFromStringFlushing() {
+        NyctTrainId trainId = NyctTrainId.buildFromString("07 0808+ MST/34H");
+
+        assertNotNull(trainId);
+        assertEquals("0", trainId.getTrainType());
+        assertEquals("7", trainId.getTrainRoute());
+        assertEquals(29310, trainId.getOriginDepartureTime());
+        assertEquals("MST", trainId.getOrigin());
+        assertEquals("34H", trainId.getDestination());
+    }
+}

--- a/src/test/java/com/kurtraschke/nyctrtproxy/model/NyctTripIdTest.java
+++ b/src/test/java/com/kurtraschke/nyctrtproxy/model/NyctTripIdTest.java
@@ -1,0 +1,85 @@
+package com.kurtraschke.nyctrtproxy.model;
+
+import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
+import com.google.transit.realtime.GtfsRealtimeNYCT;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+//Test all of the trip ID formats currently in use on the network; also exercise Flushing direction inference
+public class NyctTripIdTest {
+
+    private static TripDescriptor td(String tripId) {
+        return td(tripId, "");
+    }
+
+    private static TripDescriptor td(String tripId, String trainId) {
+        return TripDescriptor
+                .newBuilder()
+                .setTripId(tripId)
+                .setExtension(GtfsRealtimeNYCT.nyctTripDescriptor, GtfsRealtimeNYCT.NyctTripDescriptor.newBuilder().setTrainId(trainId).build())
+                .build();
+    }
+
+    @Test
+    public void buildFromTripDescriptorADivision() {
+        NyctTripId tripId = NyctTripId.buildFromTripDescriptor(td("118600_1..S03R"));
+
+        assertEquals(118600, tripId.getOriginDepartureTime());
+        assertEquals("1..S", tripId.getPathId());
+        assertEquals("03R", tripId.getNetworkId());
+        assertEquals("1", tripId.getRouteId());
+        assertEquals("S", tripId.getDirection());
+    }
+
+    @Test
+    public void buildFromTripDescriptorBDivision() {
+        NyctTripId tripId = NyctTripId.buildFromTripDescriptor(td("060800_C..S"));
+
+        assertEquals(60800, tripId.getOriginDepartureTime());
+        assertEquals("C..S", tripId.getPathId());
+        assertEquals("C", tripId.getRouteId());
+        assertEquals("S", tripId.getDirection());
+    }
+
+    @Test
+    public void buildFromTripDescriptorCanarsie() {
+        NyctTripId tripId = NyctTripId.buildFromTripDescriptor(td("044850_L..N"));
+
+        assertEquals(44850, tripId.getOriginDepartureTime());
+        assertEquals("L..N", tripId.getPathId());
+        assertEquals("L", tripId.getRouteId());
+        assertEquals("N", tripId.getDirection());
+    }
+
+    @Test
+    public void buildFromTripDescriptorFlushing() {
+        NyctTripId tripId = NyctTripId.buildFromTripDescriptor(td("117900_7..MAIN ST34", "07 1939 MST/34H"));
+
+        assertEquals(117900, tripId.getOriginDepartureTime());
+        assertEquals("7..", tripId.getPathId());
+        assertEquals("MAIN ST34", tripId.getNetworkId());
+        assertEquals("7", tripId.getRouteId());
+        assertEquals("S", tripId.getDirection());
+    }
+
+    @Test
+    public void buildFromTripDescriptorFlushingExpress() {
+        NyctTripId tripId = NyctTripId.buildFromTripDescriptor(td("116750_7X..34ST-11M", "07 1927+ 34H/MST"));
+
+        assertEquals(116750, tripId.getOriginDepartureTime());
+        assertEquals("7X.", tripId.getPathId());
+        assertEquals("34ST-11M", tripId.getNetworkId());
+        assertEquals("7X", tripId.getRouteId());
+        assertEquals("N", tripId.getDirection());
+    }
+
+
+    @Test
+    public void inferFlushingTripDirection() {
+        assertEquals("S", NyctTripId.inferFlushingDirection("07 0808+ MST/34H"));
+        assertEquals("N", NyctTripId.inferFlushingDirection("07 1131 34H/MST"));
+        assertEquals("N", NyctTripId.inferFlushingDirection("07 1709 34H/WPT"));
+    }
+
+}


### PR DESCRIPTION
Somewhat convoluted fix for new Flushing trip IDs (which look like `117900_7..MAIN ST34`):

1. Fix trip ID regexp to accommodate trip IDs which have no direction, and which have spaces and/or dashes in the path ID.
2. Add tests to `NyctTripId` for above.
3. Add new `NyctTrainId` class (with tests) for parsing train IDs.
4. Add mechanism to infer direction of travel for Flushing trips based on the origin and destination stops in the train ID.